### PR TITLE
fix 214

### DIFF
--- a/README.md
+++ b/README.md
@@ -2495,8 +2495,8 @@ We are so thankful for every contribution, which makes sure we can deliver top-n
 ### A Developer is storing sensitive documents in Amazon S3 that will require encryption at rest. The encryption keys must be rotated annually, at least. What is the easiest way to achieve this?
 
 - [ ] Encrypt the data before sending it to Amazon S3.
-- [x] Import a custom key into AWS KMS with annual rotation enabled.
-- [ ] Use AWS KMS with automatic key rotation.
+- [ ] Import a custom key into AWS KMS with annual rotation enabled.
+- [x] Use AWS KMS with automatic key rotation.
 - [ ] Export a key from AWS KMS to encrypt the data.
 
 **[⬆ Back to Top](#table-of-contents)**


### PR DESCRIPTION
AWS KMS supports automatic key rotation for symmetric encryption KMS keys with key material that AWS KMS generated (AWS_KMS origin), and you can specify a custom rotation period between 90 and 2560 days with a default of 365 days. This is the easiest solution

Import custom key with annual rotation: This is incorrect because you cannot automatically rotate KMS keys with imported key material. Imported keys only support on-demand rotation, not automatic annual rotation