### PR TITLE
fix 221 - outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -2559,7 +2559,7 @@ We are so thankful for every contribution, which makes sure we can deliver top-n
 
 - [ ] 100 per region.
 - [ ] there is no limit.
-- [x] 100 per account.
+- [x] 10.000 per account.
 - [ ] 500 per account.
 - [ ] 100 per IAM user.
 


### PR DESCRIPTION
As of November 2024, AWS increased the default S3 bucket limit from 100 to 10,000 buckets per AWS account, with the ability to request increases up to 1 million buckets