### PR TITLE
fix 265

### DIFF
--- a/README.md
+++ b/README.md
@@ -2985,9 +2985,9 @@ We are so thankful for every contribution, which makes sure we can deliver top-n
 ### If an application is storing hourly log files from thousands of instances from a high traffic web site, which naming scheme would give optimal performance on S3?
 
 - [ ] Sequential.
-- [ ] `instancelD_log-HH-DD-MM-YYYY`.
+- [x] `instancelD_log-HH-DD-MM-YYYY`.
 - [ ] `instancelDJog-YYYY-MM-DD-HH`.
-- [x] `HH-DD-MM-YYYY-log_instancelD`.
+- [ ] `HH-DD-MM-YYYY-log_instancelD`.
 - [ ] `YYYY-MM-DD-HH-logJnstancelD`.
 
 **[⬆ Back to Top](#table-of-contents)**


### PR DESCRIPTION
Either this or `instancelDJog-YYYY-MM-DD-HH`. Don't really know which is best. I think this option makes more sense than the original due to S3 prefix based partitioning. Having a different prefix for each partition let's you scale up your writes without creating hotspots. If we start with hour or date, we are writing everithing to the same partition, creating hotspot and slowing down writes. Please tell me what you think. Specially regarding `instancelDJog-HH-DD-MM-YYYY` vs `instancelDJog-YYYY-MM-DD-HH`, because I'm not sure what's the best option