### PR TITLE
fix 191

### DIFF
--- a/README.md
+++ b/README.md
@@ -2280,8 +2280,8 @@ We are so thankful for every contribution, which makes sure we can deliver top-n
 
 ### A Development team wants to immediately build and deploy an application whenever there is a change to the source code. Which approaches could be used to trigger the deployment? (Choose TWO)
 
-- [ ] Store the source code in an Amazon S3 bucket. Configure AWS CodePipeline to start whenever a file in the bucket changes.
-- [x] Store the source code in an encrypted Amazon EBS volume. Configure AWS CodePipeline to start whenever a file in the volume changes.
+- [x] Store the source code in an Amazon S3 bucket. Configure AWS CodePipeline to start whenever a file in the bucket changes.
+- [ ] Store the source code in an encrypted Amazon EBS volume. Configure AWS CodePipeline to start whenever a file in the volume changes.
 - [x] Store the source code in an AWS CodeCommit repository. Configure AWS CodePipeline to start whenever a change is committed to the repository.
 - [ ] Store the source code in an Amazon S3 bucket. Configure AWS CodePipeline to start every 15 minutes.
 - [ ] Store the source code in an Amazon EC2 instance's ephemeral storage. Configure the instance to start AWS CodePipeline whenever there are changes to the source code.


### PR DESCRIPTION
From https://docs.aws.amazon.com/codepipeline/latest/userguide/pipelines-triggers.html#pipelines-filter-considerations

"Source actions, such as CodeCommit and S3, use automated change detection to start pipelines when a change is made."