### PR TITLE
fix 75 - OUTDATED - Please READ description before merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1218,10 +1218,10 @@ We are so thankful for every contribution, which makes sure we can deliver top-n
 ### A large e-commerce site is being designed to deliver static objects from Amazon S3. The Amazon S3 bucket will server more than 300 GET requests per second. What should be done to optimize performance? (Choose TWO)
 
 - [x] Integrate Amazon CloudFront with Amazon S3.
-- [x] Enable Amazon S3 cross-region replication.
+- [ ] Enable Amazon S3 cross-region replication.
 - [ ] Delete expired Amazon S3 server log files.
-- [ ] Configure Amazon S3 lifecycle rules.Randomize Amazon S3 key name prefixes.
-- [ ] Randomize Amazon S3 key name prefixes.
+- [ ] Configure Amazon S3 lifecycle rules.
+- [x] Randomize Amazon S3 key name prefixes.
 
 **[⬆ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
I think this would be the correct fix, but it seems that since 2018 AWS announced that S3 now automatically scales to handle at least 3,500 PUT/POST/DELETE and 5,500 GET/HEAD requests per second per prefix, and explicitly removed any previous guidance to randomize object prefixes

https://aws.amazon.com/about-aws/whats-new/2018/07/amazon-s3-announces-increased-request-rate-performance/

Rather than merging I suggest considering deleting this question