### PR TITLE
fix 339

### DIFF
--- a/README.md
+++ b/README.md
@@ -3670,9 +3670,9 @@ We are so thankful for every contribution, which makes sure we can deliver top-n
 
 ### An application running on Amazon EC2 instances must access objects within an Amaon S3 busket that are encrypted using server-side encryption using AWS KMS encryption keys (SSE-KMS). The application must have access to the customer master key (CMK) to decrypt the objects. Which combination of steps will grant the application access? (Select TWO)
 
-- [x] Write an S3 bucket policy that grants the bucket access to the key.
+- [ ] Write an S3 bucket policy that grants the bucket access to the key.
 - [x] Grant access to the key in the IAM EC2 role attached to the application's EC2 instances.
-- [ ] Write a key policy that enables IAM policies to grant access to the key.
+- [x] Write a key policy that enables IAM policies to grant access to the key.
 - [ ] Grant access to the key in the S3 bucket's ACL.
 - [ ] Create a Systems Manager parameter that exposes the KMS key to the EC2 instances.
 


### PR DESCRIPTION
S3 bucket policies control access to the S3 bucket and its objects, not to KMS keys. You cannot grant a bucket access to a KMS key through a bucket policy. The principal (EC2 instance/IAM role) needs access to the key, not the bucket itself.

KMS key policies are the primary way to control access to KMS keys, and to use IAM policies to control access to a KMS key, the key policy must give the account permission to use IAM policies

https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html https://docs.aws.amazon.com/kms/latest/developerguide/control-access.html