### PR TITLE
Propose change to answer for question 350

### DIFF
--- a/README.md
+++ b/README.md
@@ -3763,9 +3763,9 @@ We are so thankful for every contribution, which makes sure we can deliver top-n
 
 ### A stock market monitoring application uses Amazon Kinesis for data ingestion. During simulated tests of peak data rates, the Kinesis stream cannot keep up with the incoming data. What step will allow Kinesis to accommodate the traffic during peak hours?
 
-- [x] Install the Kinesis Producer Library (KPL) for ingesting data into the stream.
+- [ ] Install the Kinesis Producer Library (KPL) for ingesting data into the stream.
 - [ ] Reduce the data retention period to allow for more data ingestion using `DecreaseStreamRetentionPeriod`.
-- [ ] Increase the shard count of the stream using `UpdateShardCount`.
+- [x] Increase the shard count of the stream using `UpdateShardCount`.
 - [ ] Ingest multiple records into the stream in a single call using `PutRecords`.
 
 **[⬆ Back to Top](#table-of-contents)**

--- a/README.md
+++ b/README.md
@@ -3995,8 +3995,8 @@ We are so thankful for every contribution, which makes sure we can deliver top-n
 
 - [ ] Enable a DynamoDB stream that publishes an Amazon SNS message. Trigger the Lambda function synchronously from the SNS message.
 - [ ] Enable a DynamoDB stream that publishes an SNS message. Trigger the Lambda function asynchronously from the SNS message.
-- [x] Enable a DynamoDB stream, and trigger the Lambda function synchronously from the stream.
-- [ ] Enable a DynamoDB stream, and trigger the Lambda function asynchronously from the stream.
+- [ ] Enable a DynamoDB stream, and trigger the Lambda function synchronously from the stream.
+- [x] Enable a DynamoDB stream, and trigger the Lambda function asynchronously from the stream.
 
 **[⬆ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
The question goes thus : 

**A stock market monitoring application uses Amazon Kinesis for data ingestion. During simulated tests of peak data rates, the Kinesis stream cannot keep up with the incoming data. What step will allow Kinesis to accommodate the traffic during peak hours?**

-  Install the Kinesis Producer Library (KPL) for ingesting data into the stream.
-  Reduce the data retention period to allow for more data ingestion using DecreaseStreamRetentionPeriod.
-  Increase the shard count of the stream using UpdateShardCount.
-  Ingest multiple records into the stream in a single call using PutRecords.

When the stream cannot keep up with incoming data, it means the stream write throughput capacity is being exceeded. This can only be fixed by adding more shards not using KPL. You can use KPL and still face this same issue. KPL addresses improving efficiency on the producer side, it doesn't address shard limit. And in this case, ingestion rate > provisioned write capacity. Given this explanation, I think the right answer should be C ( increase shard count ) and not A ( use KPL ) 